### PR TITLE
create custom gate and admin settings

### DIFF
--- a/assets/javascripts/discourse/templates/guest-gate.hbs
+++ b/assets/javascripts/discourse/templates/guest-gate.hbs
@@ -1,37 +1,94 @@
 {{#d-modal-body title="guest_gate.modal.title" class="guest-gate"}}
-  <div>
-    <p>{{replace-emoji (i18n 'signup_cta.intro')}}</p>
-    <p>{{replace-emoji (i18n 'signup_cta.value_prop')}}</p>
-  </div>
+  {{#if siteSettings.custom_gate_enabled }}
+    <div class="custom-gate">
+      <img src="{{ siteSettings.custom_gate_image_url }}"/>
+      <h1 style="color:{{ siteSettings.custom_gate_big_text_color }}">
+        {{ siteSettings.custom_gate_big_text }}
+      </h1>
+      <h4>
+        <span style="color:{{ siteSettings.custom_gate_little_text_color }}">
+          {{ siteSettings.custom_gate_little_text }}
+        </span>
+      </h4>
+    </div>
+    <style type="text/css">
+      .custom-gate {
+        text-align: center;
+      }
+      .custom-gate img {
+        width: 60%;
+      }
+      .custom-gate h1 {
+        margin-top: 4%;
+      }
+      .custom-gate h4 {
+        margin-top: 4%;
+        margin-bottom: 4%;
+      }
+      .modal-footer {
+        text-align: center;
+        color: {{ siteSettings.custom_gate_link_color }} !important;
+      }
+      .modal-footer a {
+        color: {{ siteSettings.custom_gate_link_color }} !important;
+      }
+      .modal-inner-container {
+        background-color: {{ siteSettings.custom_gate_background_color }} !important;
+      }
+    </style>
+  {{else}}
+    <div>
+      <p>{{replace-emoji (i18n 'signup_cta.intro')}}</p>
+      <p>{{replace-emoji (i18n 'signup_cta.value_prop')}}</p>
+    </div>
+  {{/if}}
+  <style type="text/css">
+    .modal-middle-container {
+      margin-top: 10%;
+    }
+    .mobile-view .modal-middle-container {
+      margin-top: 25% !important;
+    }
+    .gate .modal-header {
+      border-bottom: none;
+    }
+    .gate .modal-header .close {
+      margin-top: 15px;
+    }
+    .gate .modal-header h3 {
+      display: none;
+    }
+    .modal .modal-body p {
+      font-size: 14px;
+    }
+    #login-buttons {
+      margin-bottom: 0;
+      text-align: center;
+    }
+    .mobile-view #login-buttons {
+      width: 100%;
+    }
+    .mobile-view .btn-social {
+      width: 100%;
+      margin-top: 3px;
+    }
+    .modal-footer {
+      text-align: center;
+      color: #787878;
+    }
+    .modal-footer a {
+      color: #787878;
+    }
+  </style>
   {{login-buttons action="externalLogin"}}
 {{/d-modal-body}}
 <div class="modal-footer">
-{{#if ssoEnabled}}
-  {{d-button label="guest_gate.modal.log_in" action="showLogin"}}
-  &nbsp;&nbsp;or&nbsp;
-  {{d-button label="guest_gate.modal.sign_up" action="showCreateAccount"}}
-{{else}}
-  <a href {{action "showLogin"}}>{{i18n 'guest_gate.modal.log_in'}}</a>
-  .
-  <a href {{action "showCreateAccount"}}>{{i18n 'guest_gate.modal.sign_up_email'}}</a>
-{{/if}}
+  {{#if ssoEnabled}}
+    {{d-button label="guest_gate.modal.log_in" action="showLogin"}}
+    &nbsp;&nbsp;or&nbsp;
+    {{d-button label="guest_gate.modal.sign_up" action="showCreateAccount"}}
+  {{else}}
+  <a href {{action "showLogin"}}>{{i18n 'log_in'}}</a> |
+  <a href {{action "showCreateAccount"}}>{{i18n 'create_account.title'}}</a>
+  {{/if}}
 </div>
-<style type="text/css">
-  .gate .modal-header {
-    display: none;
-  }
-  .modal .modal-body p {
-    font-size: 14px;
-  }
-  #login-buttons {
-    margin-bottom: 0;
-    text-align: center;
-  }
-  .modal-footer {
-    text-align: center;
-    color: #787878;
-  }
-  .modal-footer a {
-    color: #787878;
-  }
-</style>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,13 @@ en:
   site_settings:
     guest_gate_enabled: "Enable 'Guest Gate' plugin"
     max_guest_topic_views: "How many topics a guest can view before showing the Guest Gate"
+    login_text: "Enable custom gate?"
+    signup: "Enable custom gate?"
+    custom_gate_enabled: "Enable custom gate?"
+    custom_gate_image_url: "Image url for your site logo."
+    custom_gate_big_text: "Big custom text."
+    custom_gate_little_text: "Little custom text."
+    custom_gate_big_text_color: "Big custom text color."
+    custom_gate_little_text_color: "Little custom text color."
+    custom_gate_background_color: "Custom background color."
+    custom_gate_link_color: "Custom link color."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,34 @@ plugins:
   max_guest_topic_views:
     default: 1
     client: true
+  custom_gate_enabled:
+    default: false
+    client: true
+  custom_gate_image_url:
+    type: text
+    default: ''
+    client: true
+  custom_gate_big_text:
+    type: text
+    default: 'Big custom text'
+    client: true
+  custom_gate_big_text_color:
+    type: text
+    default: '#000000'
+    client: true
+  custom_gate_little_text:
+    type: text
+    default: 'Little custom text'
+    client: true
+  custom_gate_little_text_color:
+    type: text
+    default: '#000000'
+    client: true
+  custom_gate_background_color:
+    type: text
+    default: '#FFFFFF'
+    client: true
+  custom_gate_link_color:
+    type: text
+    default: '#787878'
+    client: true


### PR DESCRIPTION
Hi Vinoth,

This pull request does not change the core behavior of the plugin: it only adds the ability to add custom gate characteristics. If enable_custom_gate is not checked, it simply defaults to the normal behavior. I also enabled the X button. Here are some screenshots:

<img width="769" alt="screen shot 2017-01-29 at 3 31 40 pm" src="https://cloud.githubusercontent.com/assets/5934106/22408607/1e2b3ca4-e639-11e6-8a7c-c8f098999a26.png">
<img width="844" alt="screen shot 2017-01-29 at 3 31 35 pm" src="https://cloud.githubusercontent.com/assets/5934106/22408608/262dbb20-e639-11e6-8612-b204e6bfdb24.png">
<img width="205" alt="screen shot 2017-01-29 at 3 18 39 pm" src="https://cloud.githubusercontent.com/assets/5934106/22408616/3a05ac66-e639-11e6-94d3-70652d9bdc5a.png">
<img width="1140" alt="screen shot 2017-01-29 at 3 20 20 pm" src="https://cloud.githubusercontent.com/assets/5934106/22408630/6b1aa1ee-e639-11e6-951e-fc72c09d62d8.png">
<img width="205" alt="screen shot 2017-01-29 at 3 19 16 pm" src="https://cloud.githubusercontent.com/assets/5934106/22408631/6b1bc632-e639-11e6-9152-c8a4c78b3aa9.png">

This is related to the discussion in https://meta.discourse.org/t/more-aggressive-method-for-asking-users-to-register-call-to-action/56040 where the proposed pop up has custom site information.

-Jeffrey